### PR TITLE
Update plugin.js

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 
 const RNElements = 'react-native-elements'
-const EXAMPLE_FILE = 'ElementsExample.js'
+const EXAMPLE_FILE = 'ElementsExample.js.ejs'
 
 const add = async function (context) {
   const { ignite } = context


### PR DESCRIPTION
DEPRECATION WARNING: addPluginComponentExample called with 'ElementsExample.js' and no .ejs extension. Add .ejs to your template filename when calling this function.
